### PR TITLE
Remove unwanted border on "stories" button

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const { RemoteBrowserTarget } = require('happo.io');
 const happoPluginStorybook = require('happo-plugin-storybook');
 
@@ -29,6 +31,8 @@ module.exports = {
   plugins: [
     happoPluginStorybook(),
   ],
+
+  stylesheets: [path.resolve(__dirname, 'styles.css')],
 
   type: 'react',
 };

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,4 @@
+button {
+  border: none;
+}
+


### PR DESCRIPTION
The (inline) styles on the "stories" button in the "Welcome" Storybook
story aren't enough to get rid of browser-default styles. By resetting
the `border` property completely, the button looks better and renders
more consistently across different browsers.